### PR TITLE
Manage td-agent.conf file with a fully qualified path

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -12,7 +12,7 @@ class fluentd::install inherits fluentd {
   } ->
 
   file { $fluentd::config_file:
-    ensure  => present,
-    content => file('fluentd/td-agent.conf'),
+    ensure => present,
+    source => 'puppet:///modules/fluentd/td-agent.conf',
   }
 }


### PR DESCRIPTION
When managing a File resource with Puppet, it's safer to define the
source with a fully qualified path rather than a relative path using
'content'.

In some cases, /etc/puppet/fluentd is actually a symlink to somewhere
else and Puppet is not able to find the actual file if using relative
path.
