### PR TITLE
Backward compatibility of provider extension

### DIFF
--- a/lib/puppet/provider/package/tdagent.rb
+++ b/lib/puppet/provider/package/tdagent.rb
@@ -1,3 +1,3 @@
-Puppet::Type.type(:package).provide(:tdagent, parent: :gem, source: :gem) do
-  commands gemcmd: '/opt/td-agent/usr/sbin/td-agent-gem'
+Puppet::Type.type(:package).provide :tdagent, :parent => :gem, :source => :gem do
+  commands :gemcmd => '/opt/td-agent/usr/sbin/td-agent-gem'
 end


### PR DESCRIPTION
The module breaks agent nodes even if they not include it, if they run on ruby 1.8.7.
In our environment there are still some redhat 6.6 boxes and for being able to use the module on our newer boxes, we needed to backport the provider extension to ruby 1.8.7 compatible stile.
Builds on Travis were succeding.
Hope you can live with this small step backward.
Cheers
Arne
