### PR TITLE
add 'install_options' feature to tdagent provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,15 @@ Default value: present
 
 Default value: 'https://rubygems.org'
 
+#### `plugin_install_options`
+
+Default value: []
+see https://docs.puppetlabs.com/puppet/latest/reference/type.html#package-provider-gem,
+e.g. 
+```puppet 
+  plugin_install_options => {'--http-proxy' => $http_proxy}`
+```
+
 The following parameters are available in the `fluentd::config` defined type:
 
 #### `title`

--- a/lib/puppet/provider/package/tdagent.rb
+++ b/lib/puppet/provider/package/tdagent.rb
@@ -1,6 +1,7 @@
 # This file must be compatible with Ruby 1.8.7 in order to work on EL6.
 module Puppet::Parser::Functions
   Puppet::Type.type(:package).provide :tdagent, :parent => :gem, :source => :gem do
+    has_feature :install_options
     commands :gemcmd => '/opt/td-agent/usr/sbin/td-agent-gem'
   end
 end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,6 +12,7 @@ class fluentd (
   $plugin_names = $fluentd::plugin_names,
   $plugin_ensure = $fluentd::plugin_ensure,
   $plugin_source = $fluentd::plugin_source,
+  $plugin_install_options = $fluentd::plugin_install_options,
   $service_name = $fluentd::service_name,
   $service_ensure = $fluentd::service_ensure,
   $service_enable = $fluentd::service_enable,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -30,6 +30,7 @@ class fluentd::params {
   $plugin_names = []
   $plugin_ensure = present
   $plugin_source = 'https://rubygems.org'
+  $plugin_install_options = []
 
   $service_name = 'td-agent'
   $service_ensure = running

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -1,12 +1,14 @@
 define fluentd::plugin(
-  $plugin_ensure = $fluentd::plugin_ensure,
-  $plugin_source = $fluentd::plugin_source,
+  $plugin_ensure          = $fluentd::plugin_ensure,
+  $plugin_source          = $fluentd::plugin_source,
+  $plugin_install_options = $fluentd::plugin_install_options,
 ) {
   package { $title:
-    ensure   => $plugin_ensure,
-    source   => $plugin_source,
-    provider => tdagent,
-    notify   => Class['Fluentd::Service'],
-    require  => Class['Fluentd::Install'],
+    ensure          => $plugin_ensure,
+    source          => $plugin_source,
+    install_options => $plugin_install_options,
+    provider        => tdagent,
+    notify          => Class['Fluentd::Service'],
+    require         => Class['Fluentd::Install'],
   }
 }


### PR DESCRIPTION
allows to pass a http proxy server to the tdagent/gem package provider. e.g.

``` puppet
  fluentd::plugin { 'gelf':
    plugin_source           => 'http://rubygems.org',
    plugin_install_options  => {'--http-proxy' => $http_proxy},
  }
```
