### PR TITLE
Feature/ruby1.8.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+## 2016-03-03 - Release Branch feature/ruby1.8.7 
+
+ - params.pp : for backward compatibility with ruby 1.8.7 seems to work better when moving the conditional check for serviceprovider ( https://tickets.puppetlabs.com/browse/PUP-5296 ) into the osfamily catch block.
+ - install_repo.pp : added a conditional if-block if we dont want to specify ( or cant use for whatever reason ) the gpgkey for the case of redhat/centos rpms.   
+
 ## 2016-01-22 - Release v. 0.3.2
 
  - Purge unmanaged config files

--- a/lib/puppet/provider/package/tdagent.rb
+++ b/lib/puppet/provider/package/tdagent.rb
@@ -1,3 +1,3 @@
-Puppet::Type.type(:package).provide(:tdagent, parent: :gem, source: :gem) do
-  commands gemcmd: '/opt/td-agent/usr/sbin/td-agent-gem'
+Puppet::Type.type(:package).provide :tdagent, :parent => :gem, :source => :gem do
+  commands :gemcmd => '/opt/td-agent/usr/sbin/td-agent-gem'
 end

--- a/manifests/install_repo.pp
+++ b/manifests/install_repo.pp
@@ -1,19 +1,34 @@
 class fluentd::install_repo inherits fluentd {
   case $::osfamily {
     'redhat': {
-      yumrepo { $fluentd::repo_name:
-        descr    => $fluentd::repo_desc,
-        baseurl  => $fluentd::repo_url,
-        enabled  => $fluentd::repo_enabled,
-        gpgcheck => $fluentd::repo_gpgcheck,
-        gpgkey   => $fluentd::repo_gpgkey,
-        notify   => Exec['rpmkey'],
-      }
+      if $fluentd::repo_gpgcheck {
+        # lets do a gpgcheck f we can as part of the repo definition and force an rpm import using the current gpgkey ...
 
-      exec { 'rpmkey':
-        command     => "rpm --import ${fluentd::repo_gpgkey}",
-        path        => '/usr/bin',
-        refreshonly => true,
+         yumrepo { $fluentd::repo_name:
+           descr    => $fluentd::repo_desc,
+           baseurl  => $fluentd::repo_url,
+           enabled  => $fluentd::repo_enabled,
+           gpgcheck => $fluentd::repo_gpgcheck,
+           gpgkey   => $fluentd::repo_gpgkey,
+           notify   => Exec['rpmkey'],
+         }
+
+         exec { 'rpmkey':
+           command     => "rpm --import ${fluentd::repo_gpgkey}",
+           path        => '/usr/bin',
+           refreshonly => true,
+         }
+      }
+      else {
+        # we dont have the gpgkey so lets not do a gpgcheck as part of the repo definition
+
+         yumrepo { $fluentd::repo_name:
+           descr    => $fluentd::repo_desc,
+           baseurl  => $fluentd::repo_url,
+           enabled  => $fluentd::repo_enabled,
+           gpgcheck => $fluentd::repo_gpgcheck,
+         }
+
       }
 
       # TODO: Remove this dependency. Gem provider requires this package.

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,6 +6,7 @@ class fluentd::params {
   case $::osfamily {
     'redhat': {
       $repo_url = 'http://packages.treasuredata.com/2/redhat/$releasever/$basearch'
+      $service_provider = 'redhat'
     }
 
     'debian': {
@@ -38,7 +39,7 @@ class fluentd::params {
 
   # Workaround for the following issue:
   # https://tickets.puppetlabs.com/browse/PUP-5296
-  $service_provider = if $::osfamily == 'redhat' { 'redhat' }
+  #$service_provider = if $::osfamily == 'redhat' { 'redhat' }
 
   $config_file = '/etc/td-agent/td-agent.conf'
   $config_path = '/etc/td-agent/config.d'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,6 +6,8 @@ class fluentd::params {
   case $::osfamily {
     'redhat': {
       $repo_url = 'http://packages.treasuredata.com/2/redhat/$releasever/$basearch'
+      # Workaround for the following issue:
+      # https://tickets.puppetlabs.com/browse/PUP-5296
       $service_provider = 'redhat'
     }
 
@@ -36,10 +38,6 @@ class fluentd::params {
   $service_ensure = running
   $service_enable = true
   $service_manage = true
-
-  # Workaround for the following issue:
-  # https://tickets.puppetlabs.com/browse/PUP-5296
-  #$service_provider = if $::osfamily == 'redhat' { 'redhat' }
 
   $config_file = '/etc/td-agent/td-agent.conf'
   $config_path = '/etc/td-agent/config.d'


### PR DESCRIPTION
Hi Soylent/Konstantin,

Can you please take a look at my Pull Request  for your Fluentd puppet module on github ?

I am putting in some changes which we ( My colleague Arne Hingst and I ) had to make and that we are currently using for backward compatibility for ruby 1.8.7 on some (but not all) platforms for our current project that we are deploying to.

I have also put in some conditional checks for redhat/centos family for the case where you may not have or may not want to use gpgkey for rpm installs from the repo.

All changes are in a separate branch 'feature/ruby1.8.7'.

Please let me know your comments / suggestions.

Many Thanks.

Matt_C.
