### PR TITLE
Set default file permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,14 @@ Default value: true
 
 Default value: '/etc/td-agent/td-agent.conf'
 
+#### `config_owner`
+
+Default value: 'td-agent'
+
+#### `config_group`
+
+Default value: 'td-agent'
+
 ### Public Defines
 
 * `fluentd::config`: Generates custom configuration files.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,6 +21,8 @@ class fluentd (
   $service_enable = $::fluentd::params::service_enable,
   $service_manage = $::fluentd::params::service_manage,
   $config_file = $::fluentd::params::config_file,
+  $config_owner = $::fluentd::params::config_owner,
+  $config_group = $::fluentd::params::config_group,
 ) inherits fluentd::params {
 
   # Param validations
@@ -41,6 +43,8 @@ class fluentd (
   validate_bool($service_enable)
   validate_bool($service_manage)
   validate_absolute_path($config_file)
+  validate_string($config_owner)
+  validate_string($config_group)
 
   contain fluentd::install
   contain fluentd::service

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -11,7 +11,7 @@ class fluentd::install inherits fluentd {
     ensure  => directory,
     owner   => 'root',
     group   => 'root',
-    mode    => '0755',
+    mode    => '0750',
     recurse => true,
     force   => true,
     purge   => true,
@@ -22,6 +22,6 @@ class fluentd::install inherits fluentd {
     source => 'puppet:///modules/fluentd/td-agent.conf',
     owner  => 'root',
     group  => 'root',
-    mode   => '0644',
+    mode   => '0640',
   }
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -9,6 +9,9 @@ class fluentd::install inherits fluentd {
 
   file { $fluentd::config_path:
     ensure  => directory,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0755',
     recurse => true,
     force   => true,
     purge   => true,
@@ -17,5 +20,8 @@ class fluentd::install inherits fluentd {
   file { $fluentd::config_file:
     ensure => present,
     source => 'puppet:///modules/fluentd/td-agent.conf',
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0644',
   }
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -9,8 +9,8 @@ class fluentd::install inherits fluentd {
 
   file { $fluentd::config_path:
     ensure  => directory,
-    owner   => 'root',
-    group   => 'root',
+    owner   => $fluentd::config_owner,
+    group   => $fluentd::config_group,
     mode    => '0750',
     recurse => true,
     force   => true,
@@ -20,8 +20,8 @@ class fluentd::install inherits fluentd {
   file { $fluentd::config_file:
     ensure => present,
     source => 'puppet:///modules/fluentd/td-agent.conf',
-    owner  => 'root',
-    group  => 'root',
+    owner  => $fluentd::config_owner,
+    group  => $fluentd::config_group,
     mode   => '0640',
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -47,4 +47,6 @@ class fluentd::params {
 
   $config_file = '/etc/td-agent/td-agent.conf'
   $config_path = '/etc/td-agent/config.d'
+  $config_owner = 'td-agent'
+  $config_group = 'td-agent'
 }


### PR DESCRIPTION
This will avoid the situation that the config file ends up being owned by a random user depending on the resource catalog evaluation order.

E.g. right now I can see in our puppet logs things like 

```
Notice: /Stage[main]/Fluentd::Install/File[/etc/td-agent/td-agent.conf]/owner: owner changed 'root' to 'ubuntu'
Notice: /Stage[main]/Fluentd::Install/File[/etc/td-agent/td-agent.conf]/group: group changed 'root' to 'ubuntu'
Notice: /Stage[main]/Fluentd::Install/File[/etc/td-agent/td-agent.conf]/mode: mode changed '0644' to '0444'
```
