### PR TITLE
fix service issues on RHEL 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,10 @@ Default value: 'td-agent'
 
 Default value: present
 
+#### `plugin_provider`
+
+Default value: tdagent
+
 #### `service_name`
 
 Default value: 'td-agent'
@@ -158,6 +162,13 @@ Default value: true
 #### `service_manage`
 
 Default value: true
+
+#### `service_provider`
+
+Default value:
+
+  - when `$::osfamily == 'redhat'`: redhat
+  - otherwise: undef
 
 #### `config_file`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,6 +21,7 @@ class fluentd (
   $service_ensure = $::fluentd::params::service_ensure,
   $service_enable = $::fluentd::params::service_enable,
   $service_manage = $::fluentd::params::service_manage,
+  $service_provider = $::fluentd::params::service_provider,
   $config_file = $::fluentd::params::config_file,
   $config_path = $::fluentd::params::config_path,
   $config_owner = $::fluentd::params::config_owner,


### PR DESCRIPTION
RHEL 7 uses systemd for managing services, so setting service_provider to
"redhat" by default results in an error.  This change (a) sets service_provider
to undef in all cases, and (b) exposes a service_provider parameter in init.pp
to allow this to be set if necessary by a calling manifest.

Closes #14.
