### PR TITLE
Add versionable feature to td-agent-gem provider

### DIFF
--- a/lib/puppet/provider/package/tdagent.rb
+++ b/lib/puppet/provider/package/tdagent.rb
@@ -1,7 +1,7 @@
 # This file must be compatible with Ruby 1.8.7 in order to work on EL6.
 module Puppet::Parser::Functions
   Puppet::Type.type(:package).provide :tdagent, :parent => :gem, :source => :gem do
-    has_feature :install_options
+    has_feature :install_options, :versionable
     commands :gemcmd => '/opt/td-agent/usr/sbin/td-agent-gem'
   end
 end


### PR DESCRIPTION
In case someone wants to specify gem version, td-agent-gem provider must have :versionable feature added. 
