### PR TITLE
Define configs and plugins in Hiera

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
  - Add param `plugins`
+ - Add param `configs`
 
 ## 2016-10-13 - Release v. 0.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+ - Add param `plugins`
+
 ## 2016-10-13 - Release v. 0.7.0
 
  - Add param `service_provider` (@larsks)

--- a/README.md
+++ b/README.md
@@ -79,6 +79,18 @@ fluentd::config { '600_forwarding.conf':
 }
 ```
 
+### Hiera Support
+
+Defining Fluentd resources in Hiera.
+
+```yaml
+fluentd::plugins:
+  'fluent-plugin-http':
+    ensure: 0.1.0
+  'fluent-plugin-elasticsearch':
+    ensure: present
+```
+
 ### Config File Naming
 
 All configs employ a numbering system in the resource's title that is used for
@@ -185,6 +197,10 @@ Default value: 'td-agent'
 #### `config_group`
 
 Default value: 'td-agent'
+
+#### `plugins`
+
+Default value: {}
 
 ### Public Defines
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,16 @@ fluentd::plugins:
     ensure: 0.1.0
   'fluent-plugin-elasticsearch':
     ensure: present
+fluentd::configs:
+  '100_fwd.conf':
+    config:
+      source:
+        type: forward
+  '200_stdout.conf':
+    config:
+      match:
+        tag_pattern: test
+        type: stdout
 ```
 
 ### Config File Naming
@@ -197,6 +207,10 @@ Default value: 'td-agent'
 #### `config_group`
 
 Default value: 'td-agent'
+
+#### `configs`
+
+Default value: {}
 
 #### `plugins`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,6 +26,7 @@ class fluentd (
   $config_path = $::fluentd::params::config_path,
   $config_owner = $::fluentd::params::config_owner,
   $config_group = $::fluentd::params::config_group,
+  $configs = $::fluentd::params::configs,
   $plugins = $::fluentd::params::plugins,
 ) inherits fluentd::params {
 
@@ -89,4 +90,5 @@ class fluentd (
   Class['Fluentd::Service']
 
   create_resources('fluentd::plugin', $plugins)
+  create_resources('fluentd::config', $configs)
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,6 +26,7 @@ class fluentd (
   $config_path = $::fluentd::params::config_path,
   $config_owner = $::fluentd::params::config_owner,
   $config_group = $::fluentd::params::config_group,
+  $plugins = $::fluentd::params::plugins,
 ) inherits fluentd::params {
 
   validate_bool($repo_install)
@@ -86,4 +87,6 @@ class fluentd (
 
   Class['Fluentd::Install'] ->
   Class['Fluentd::Service']
+
+  create_resources('fluentd::plugin', $plugins)
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -50,6 +50,7 @@ class fluentd::params {
   $config_path = '/etc/td-agent/config.d'
   $config_owner = 'td-agent'
   $config_group = 'td-agent'
+  $configs = {}
 
   $plugins = {}
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -50,4 +50,6 @@ class fluentd::params {
   $config_path = '/etc/td-agent/config.d'
   $config_owner = 'td-agent'
   $config_group = 'td-agent'
+
+  $plugins = {}
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -12,7 +12,16 @@ RSpec.describe 'fluentd' do
     include_examples 'works'
   end
 
-  context 'with defaults for all parameters', :redhat do
+  context 'with redhat', :redhat do
     include_examples 'works'
+  end
+
+  context 'with plugins', :redhat do
+    let(:params) { { plugins: { plugin_name => plugin_params } } }
+
+    let(:plugin_name) { 'fluent-plugin-http' }
+    let(:plugin_params) { { 'plugin_ensure' => '0.1.0' } }
+
+    it { is_expected.to contain_fluentd__plugin(plugin_name).with(plugin_params) }
   end
 end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -24,4 +24,13 @@ RSpec.describe 'fluentd' do
 
     it { is_expected.to contain_fluentd__plugin(plugin_name).with(plugin_params) }
   end
+
+  context 'with configs', :redhat do
+    let(:params) { { configs: { config_name => config_params } } }
+
+    let(:config_name) { '100_fwd.conf' }
+    let(:config_params) { { 'config' => { 'source' => { 'type' => 'forward' } } } }
+
+    it { is_expected.to contain_fluentd__config(config_name).with(config_params) }
+  end
 end

--- a/spec/defines/plugin_spec.rb
+++ b/spec/defines/plugin_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 RSpec.describe 'fluentd::plugin' do
   let(:pre_condition) { 'include fluentd' }
+
   let(:title) { 'fluent-plugin-test' }
 
   context 'with redhat', :redhat do


### PR DESCRIPTION
Now you can define Fluentd configs and plugins in Hiera:
```puppet
include fluentd
```

```yaml
fluentd::plugins:
  'fluent-plugin-http':
    ensure: 0.1.0
  'fluent-plugin-elasticsearch':
    ensure: present
fluentd::configs:
  '100_fwd.conf':
    config:
      source:
        type: forward
  '200_stdout.conf':
    config:
      match:
        tag_pattern: 'test'
        type: stdout
```