### PR TITLE
fix plugin_install_options example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ see https://docs.puppetlabs.com/puppet/latest/reference/type.html#package-provid
 e.g.
 
 ```puppet
-plugin_install_options => {'--http-proxy' => $http_proxy}`
+plugin_install_options => [{'--http-proxy' => $http_proxy}]
 ```
 
 The following parameters are available in the `fluentd::config` defined type:


### PR DESCRIPTION
The parameter plugin_install_options of fluentd::plugin is of type
Array[Variant[String, Hash]] - in the README.md it is used as if it were
of type Hash.