### PR TITLE
Specify versions of dependent modules

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,6 +1,10 @@
 fixtures:
   repositories:
-    stdlib: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
-    apt: "git://github.com/puppetlabs/puppetlabs-apt.git"
+    stdlib:
+      repo: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
+      ref: "4.19.0"
+    apt:
+      repo: "git://github.com/puppetlabs/puppetlabs-apt.git"
+      ref: "2.4.0"
   symlinks:
     fluentd: "#{source_dir}"


### PR DESCRIPTION
The latest versions of dependent modules can be incompatible with current version of this module. Update of the dependencies should be done explicitly.