### PR TITLE
Use the latest version of `puppetlabs/apt`

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,6 +5,6 @@ fixtures:
       ref: "4.19.0"
     apt:
       repo: "git://github.com/puppetlabs/puppetlabs-apt.git"
-      ref: "2.4.0"
+      ref: "4.1.0"
   symlinks:
     fluentd: "#{source_dir}"

--- a/metadata.json
+++ b/metadata.json
@@ -7,7 +7,7 @@
         },
         {
             "name": "puppetlabs/apt",
-            "version_requirement": "2.x"
+            "version_requirement": ">= 2.0.0 < 5.0.0"
         }
     ],
     "issues_url": "https://github.com/soylent/konstantin-fluentd/issues",

--- a/spec/support/facts.rb
+++ b/spec/support/facts.rb
@@ -16,8 +16,14 @@ RSpec.shared_context 'debian', :debian do
       osfamily: 'Debian',
       lsbdistid: 'Ubuntu',
       lsbdistcodename: 'trusty',
-      lsbdistrelease: '14.04',
-      puppetversion: Puppet.version
+      # NOTE: Module `puppetlabs/apt` uses structured facts
+      # Please see: https://tickets.puppetlabs.com/browse/MODULES-4792
+      os: {
+        name: 'Ubuntu',
+        release: {
+          full: '14.04'
+        }
+      }
     }
   end
 end


### PR DESCRIPTION
I had to also update facts for Debian in the tests because the new version of `puppetlabs/apt` uses structured facts. Please see https://tickets.puppetlabs.com/browse/MODULES-4792

Resolves #30