### PR TITLE
Fix tests

### DIFF
--- a/examples/elasticsearch.pp
+++ b/examples/elasticsearch.pp
@@ -1,5 +1,13 @@
 include fluentd
 
+package { [
+  'gcc',
+  'make',
+]:
+  ensure => installed,
+  before => Fluentd::Plugin['fluent-plugin-elasticsearch'],
+}
+
 fluentd::plugin { 'fluent-plugin-elasticsearch': }
 
 fluentd::config { '500_elasticsearch.conf':


### PR DESCRIPTION
The tests are failing because of the following error:

```
  Error: Execution of '/opt/td-agent/usr/sbin/td-agent-gem install --source https://rubygems.org fluent-plugin-elasticsearch' returned 1: Successfully installed serverengine-2.0.5
  Building native extensions.  This could take a while...
  ERROR:  Error installing fluent-plugin-elasticsearch:
  	ERROR: Failed to build gem native extension.
  
      current directory: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/strptime-0.2.1/ext/strptime
  /opt/td-agent/embedded/bin/ruby -r ./siteconf20171224-1197-v6saqt.rb extconf.rb
  checking for rb_timespec_now()... *** extconf.rb failed ***
  Could not create Makefile due to some reason, probably lack of necessary
  libraries and/or headers.  Check the mkmf.log file for more details.  You may
  need configuration options.
  
  Provided configuration options:
  	--with-opt-dir
  	--with-opt-include
  	--without-opt-include=${opt-dir}/include
  	--with-opt-lib
  	--without-opt-lib=${opt-dir}/lib
  	--with-make-prog
  	--without-make-prog
  	--srcdir=.
  	--curdir
  	--ruby=/opt/td-agent/embedded/bin/ruby
  /opt/td-agent/embedded/lib/ruby/2.1.0/mkmf.rb:467:in `try_do': The compiler failed to generate an executable file. (RuntimeError)
  You have to install development tools first.
  	from /opt/td-agent/embedded/lib/ruby/2.1.0/mkmf.rb:552:in `try_link0'
  	from /opt/td-agent/embedded/lib/ruby/2.1.0/mkmf.rb:567:in `try_link'
  	from /opt/td-agent/embedded/lib/ruby/2.1.0/mkmf.rb:747:in `try_func'
  	from /opt/td-agent/embedded/lib/ruby/2.1.0/mkmf.rb:1032:in `block in have_func'
  	from /opt/td-agent/embedded/lib/ruby/2.1.0/mkmf.rb:923:in `block in checking_for'
  	from /opt/td-agent/embedded/lib/ruby/2.1.0/mkmf.rb:351:in `block (2 levels) in postpone'
  	from /opt/td-agent/embedded/lib/ruby/2.1.0/mkmf.rb:321:in `open'
  	from /opt/td-agent/embedded/lib/ruby/2.1.0/mkmf.rb:351:in `block in postpone'
  	from /opt/td-agent/embedded/lib/ruby/2.1.0/mkmf.rb:321:in `open'
  	from /opt/td-agent/embedded/lib/ruby/2.1.0/mkmf.rb:347:in `postpone'
  	from /opt/td-agent/embedded/lib/ruby/2.1.0/mkmf.rb:922:in `checking_for'
  	from /opt/td-agent/embedded/lib/ruby/2.1.0/mkmf.rb:1031:in `have_func'
  	from extconf.rb:3:in `<main>'
  
  To see why this extension failed to compile, please check the mkmf.log which can be found here:
  
    /opt/td-agent/embedded/lib/ruby/gems/2.1.0/extensions/x86_64-linux/2.1.0/strptime-0.2.1/mkmf.log
  
  extconf failed, exit code 1
  
  Gem files will remain installed in /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/strptime-0.2.1 for inspection.
  Results logged to /opt/td-agent/embedded/lib/ruby/gems/2.1.0/extensions/x86_64-linux/2.1.0/strptime-0.2.1/gem_make.out
```

https://travis-ci.org/soylent/konstantin-fluentd/jobs/270782716#L1312