### PR TITLE
Add ensure parameter to fluentd::config

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,8 +1,11 @@
-define fluentd::config($config) {
+define fluentd::config(
+  Enum['present','absent']  $ensure = 'present',
+  Hash $config = {},
+) {
   include fluentd
 
   file { "${fluentd::config_path}/${title}":
-    ensure  => present,
+    ensure  => $ensure,
     content => fluent_config($config),
     require => Class['Fluentd::Install'],
     notify  => Class['Fluentd::Service'],

--- a/spec/defines/config_spec.rb
+++ b/spec/defines/config_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe 'fluentd::config' do
 
       it do
         is_expected.to contain_file('/etc/td-agent/config.d/stdout.conf').
+          with(:ensure => 'present').
           with_content(/<match \*\*>/).
           with_content(/@type forward/).
           with_content(/<server>/).
@@ -32,6 +33,20 @@ RSpec.describe 'fluentd::config' do
           with_content(/<\/server>/).
           with_content(/host example2.com/).
           with_content(/<\/match>/)
+      end
+    end
+
+    context 'when config contains ensure absent' do
+      let(:params) do
+        {
+          ensure: 'absent',
+          config: { }
+        }
+      end
+
+      it do
+        is_expected.to contain_file('/etc/td-agent/config.d/stdout.conf').
+          with(:ensure => 'absent')
       end
     end
   end


### PR DESCRIPTION
Add an ensure parameter to fluentd::config to be able to remove unwanted configuration files. 