### PR TITLE
Fix module for puppet 6 support

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -6,5 +6,8 @@ fixtures:
     apt:
       repo: "git://github.com/puppetlabs/puppetlabs-apt.git"
       ref: "4.1.0"
+    yumrepo_core:
+      repo: "git://github.com/puppetlabs/puppetlabs-yumrepo_core.git"
+      ref: "1.0.3"
   symlinks:
     fluentd: "#{source_dir}"

--- a/lib/puppet/provider/package/tdagent.rb
+++ b/lib/puppet/provider/package/tdagent.rb
@@ -1,7 +1,7 @@
-# This file must be compatible with Ruby 1.8.7 in order to work on EL6.
-module Puppet::Parser::Functions
-  Puppet::Type.type(:package).provide :tdagent, :parent => :gem, :source => :gem do
-    has_feature :install_options, :versionable
-    commands :gemcmd => '/opt/td-agent/usr/sbin/td-agent-gem'
-  end
+require 'puppet'
+require 'puppet/provider/package'
+
+Puppet::Type.type(:package).provide :tdagent, :parent => :gem, :source => :gem do
+  has_feature :install_options, :versionable
+  commands :gemcmd => '/opt/td-agent/usr/sbin/td-agent-gem'
 end

--- a/metadata.json
+++ b/metadata.json
@@ -8,6 +8,10 @@
         {
             "name": "puppetlabs/apt",
             "version_requirement": ">= 2.0.0 < 5.0.0"
+        },
+        {
+            "name": "puppetlabs/yumrepo_core",
+            "version_requirement": ">= 1.0.0 < 2.0.0"
         }
     ],
     "issues_url": "https://github.com/soylent/konstantin-fluentd/issues",

--- a/spec/acceptance/nodesets/centos-6-x64.yml
+++ b/spec/acceptance/nodesets/centos-6-x64.yml
@@ -6,7 +6,7 @@ HOSTS:
     docker_preserve_image: true
     docker_cmd: '["/sbin/init"]'
     docker_image_commands:
-      - 'yum install -y tar'
+      - 'yum install -y tar ruby ruby-devel make gcc'
 CONFIG:
   log_level: verbose
   type: foss

--- a/spec/acceptance/nodesets/centos-7-x64.yml
+++ b/spec/acceptance/nodesets/centos-7-x64.yml
@@ -6,7 +6,7 @@ HOSTS:
     docker_preserve_image: true
     docker_cmd: '["/sbin/init"]'
     docker_image_commands:
-      - 'yum install -y initscripts'
+      - 'yum install -y initscripts ruby ruby-devel make gcc'
 CONFIG:
   log_level: verbose
   type: foss

--- a/spec/defines/plugin_spec.rb
+++ b/spec/defines/plugin_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 RSpec.describe 'fluentd::plugin' do
   let(:title) { 'fluent-plugin-test' }
+  let(:pre_condition) { 'include ::fluentd' }
 
   context 'with redhat', :redhat do
     it { is_expected.to contain_package(title).with(provider: 'tdagent') }

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -14,6 +14,7 @@ RSpec.configure do |c|
     hosts.each do |host|
       on host, puppet('module', 'install', 'puppetlabs-stdlib')
       on host, puppet('module', 'install', 'puppetlabs-apt')
+      on host, puppet('module', 'install', 'puppetlabs-yumrepo_core')
     end
   end
 end


### PR DESCRIPTION
We don't need to wrap the definition in a parser function as it should
just be loaded.

Fixes: #39